### PR TITLE
Added a basic graphical interface

### DIFF
--- a/app/src/main/java/app/LibreMesh.java
+++ b/app/src/main/java/app/LibreMesh.java
@@ -23,6 +23,10 @@ public class LibreMesh extends AppCompatActivity {
     private ConnectivityManager connectivityManager;
     private WifiManager wifiManager;
 
+    @Override
+    public void onBackPressed() {
+        // Do Here what ever you want do on back press;
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/app/NetworkAccessManager.java
+++ b/app/src/main/java/app/NetworkAccessManager.java
@@ -24,7 +24,7 @@ public class NetworkAccessManager extends AppCompatActivity {
         connectivityManager.requestNetwork(networkRequest, new ConnectivityManager.NetworkCallback() {
             @Override
             public void onAvailable(Network network) {
-                if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
                     connectivityManager.bindProcessToNetwork(network);
                 else
                     ConnectivityManager.setProcessDefaultNetwork(network);
@@ -32,7 +32,7 @@ public class NetworkAccessManager extends AppCompatActivity {
 
             @Override
             public void onLost(Network network) {
-                if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
                     connectivityManager.bindProcessToNetwork(null);
                 else
                     ConnectivityManager.setProcessDefaultNetwork(null);
@@ -54,7 +54,7 @@ public class NetworkAccessManager extends AppCompatActivity {
         connectivityManager.requestNetwork(networkRequest, new ConnectivityManager.NetworkCallback() {
             @Override
             public void onAvailable(Network network) {
-                if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
                     connectivityManager.bindProcessToNetwork(network);
                 else
                     ConnectivityManager.setProcessDefaultNetwork(network);
@@ -62,7 +62,7 @@ public class NetworkAccessManager extends AppCompatActivity {
 
             @Override
             public void onLost(Network network) {
-                if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
                     connectivityManager.bindProcessToNetwork(null);
                 else
                     ConnectivityManager.setProcessDefaultNetwork(null);

--- a/app/src/main/res/drawable/button_bg.xml
+++ b/app/src/main/res/drawable/button_bg.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" >
+<solid android:color="#00FFFFFF" />`<!--Background Color-->`
+<stroke android:width="2dip" android:color="#FFFFFF"/> `<!--Border-->`
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -3,52 +3,70 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/LibreMesh"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="#808080"
     tools:context="app.MainActivity">
 
-    <Button
-        android:id="@+id/verificaRedButton"
+    <TextView
+        android:id="@+id/errorTitle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="317dp"
-        android:layout_marginBottom="366dp"
-        android:onClick="informConnectionToLibreMesh"
-        android:text="@string/verificar_red"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginStart="13dp"
+        android:layout_marginTop="109dp"
+        android:layout_marginBottom="199dp"
+        android:text="No es posible ingresar a la LimeApp"
+        android:textAlignment="center"
+        android:textColor="#FFFFFF"
+        android:textSize="24sp"
+        android:visibility="invisible"
+        app:layout_constraintBottom_toTopOf="@+id/LibreMeshText"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.492" />
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tips"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginStart="18dp"
+        android:layout_marginEnd="18dp"
+        android:layout_marginBottom="61dp"
+        android:text=""
+        android:textColor="#FFFFFF"
+        android:textSize="20sp"
+        android:visibility="invisible"
+        app:layout_constraintBottom_toTopOf="@+id/retryButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/errorTitle" />
 
     <Button
-        android:id="@+id/obtieneIpButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="317dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginBottom="366dp"
-        android:onClick="informPrivateIp"
-        android:text="@string/obtener_ip"
+        android:id="@+id/retryButton"
+        android:layout_width="223dp"
+        android:layout_height="89dp"
+        android:layout_marginBottom="173dp"
+        android:background="@drawable/button_bg"
+        android:onClick="retry"
+        android:text="Reintentar"
+        android:textColor="#FFFFFF"
+        android:textSize="24sp"
+        android:visibility="invisible"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.487" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tips" />
 
-    <Button
-        android:id="@+id/accederButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="431dp"
-        android:layout_marginBottom="252dp"
-        android:onClick="accessToLibreMesh"
-        android:text="@string/accederButton"
+    <TextView
+        android:id="@+id/LibreMeshText"
+        android:layout_width="213dp"
+        android:layout_height="0dp"
+        android:layout_marginBottom="340dp"
+        android:text="LibreMesh"
+        android:textAlignment="center"
+        android:textSize="34sp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/obtieneIpButton"
-        app:layout_constraintHorizontal_bias="0.552"
-        app:layout_constraintStart_toEndOf="@+id/verificaRedButton"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.484" />
-
-
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/errorTitle" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,14 +1,13 @@
 <resources>
     <string name="app_name">LibreMesh-app</string>
-    <string name="verificar_red">Verificar red</string>
-    <string name="obtener_ip">Obtener IP</string>
-    <string name="accederButton">Acceder a LibreMesh</string>
     <string name="title_activity_libre_mesh">LibreMesh</string>
     <!-- Strings used for fragments for navigation -->
     <string name="first_fragment_label">First Fragment</string>
     <string name="second_fragment_label">Second Fragment</string>
     <string name="next">Next</string>
     <string name="previous">Previous</string>
+
+    <string name="tips"><![CDATA[• Verificá que estás conectado/a a la <b>red wifi</b> de la red comunitaria.<br>• Verificá que tu nodo esté <b>encendido</b>.<br>• Si tenés un router interno, probá conectándote <b>directamente al router del techo</b>]]></string>
 
     <string name="hello_first_fragment">Hello first fragment</string>
     <string name="hello_second_fragment">Hello second fragment. Arg: %1$s</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.LimeApp" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.LimeApp" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_500</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>


### PR DESCRIPTION
This PR includes a basic graphical user interface that allows the user to directly enter the Lime-App without pressing any button. In the event of a fault, a general error will be indicated with instructions to follow to solve frequent problems.

Error message:
![LibreMesh error](https://user-images.githubusercontent.com/42981462/127045224-21f28cc6-01a6-42e4-a091-1ce1f61b5c21.jpeg)
