### PR TITLE
Fix verifywifi state

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
 
     <application
+        android:usesCleartextTraffic="true"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/app/MainActivity.java
+++ b/app/src/main/java/app/MainActivity.java
@@ -39,7 +39,7 @@ public class MainActivity extends AppCompatActivity {
                     e.printStackTrace();
                     return;
                 }
-                connection.setConnectTimeout(100);
+                connection.setConnectTimeout(5000);
                 try {
                     connection.getInputStream();
                     success[0] = true;
@@ -125,11 +125,15 @@ public class MainActivity extends AppCompatActivity {
                 startActivity(myIntent);
                 finish();
                 return true;
-            } else
+            } else {
                 System.out.println("No está en una red LibreMesh");
+                Toast.makeText(getApplicationContext(), "Error en HTTPGet", Toast.LENGTH_LONG).show();
+            }
         }
-        else
+        else {
             System.out.println("No está conectado a la Wi-Fi");
+            Toast.makeText(getApplicationContext(), "No se esta detectando una conexion a WiFi", Toast.LENGTH_LONG).show();
+        }
         return false;
     }
 

--- a/app/src/main/java/app/NetworkAccessManager.java
+++ b/app/src/main/java/app/NetworkAccessManager.java
@@ -88,10 +88,9 @@ public class NetworkAccessManager extends AppCompatActivity {
     }
 
     public static boolean verifyWifiConnection(WifiManager wm) {
-        if (wm.isWifiEnabled()) {
-            return wm.getConnectionInfo().getNetworkId() != -1;
-        }
-        return false;
+        if(Build.VERSION.SDK_INT <= Build.VERSION_CODES.P)
+            return wm.isWifiEnabled() && wm.getConnectionInfo().getNetworkId() != -1;
+        return wm.isWifiEnabled();
     }
 
     public static String getGateway(WifiManager wm) {


### PR DESCRIPTION
This PR changes the timeout from 100 to 5000, adds an android verification to choose if it checks or not the ID of the Wifi connected network, and enables the use of normal HTTP pages.